### PR TITLE
Dependencies and setup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 
+. # installs ods-api
 attrs==23.1.0
 boto3==1.28.2
 botocore==1.31.2
@@ -7,7 +8,7 @@ cffi==1.15.1
 charset-normalizer==3.2.0
 click==8.1.4
 cryptography==42.0.4
-dlx @ git+https://github.com/dag-hammarskjold-library/dlx@a846c3dd38fcbb6e34f5cf6938b130bd561f8257
+dlx @ git+https://github.com/dag-hammarskjold-library/dlx@v1.4.1
 dnspython==2.6.1
 idna==3.7
 Jinja2==3.1.3
@@ -16,10 +17,9 @@ joblib==1.3.1
 jsonschema==4.0.0
 lxml==4.9.3
 MarkupSafe==2.1.3
-mongomock==3.23.0
+mongomock==4.1.2
 moto==2.3.1
 nltk==3.6.7
-ods-api==0.1
 pycparser==2.21
 pymongo==4.6.3
 pyrsistent==0.19.3

--- a/setup.py
+++ b/setup.py
@@ -20,11 +20,10 @@ setup(
     description = 'Download files from ODS',
     long_description = long_description,
     long_description_content_type = "text/markdown",
-    python_requires = '>=3.5',
+    python_requires = '>=3.8, <3.12',
     entry_points = {
         'console_scripts': [
             'ods-dlx=ods_api.script.ods_dlx:run'
         ]
     }
 )
-


### PR DESCRIPTION
* Resolves dependency conflicts 
* Prevents installation using Python 3.12. Dependencies do not currently install correctly on 3.12